### PR TITLE
[EPO-793] Add autoRun tags to foundational notebook.

### DIFF
--- a/properties_of_stars/foundational.ipynb
+++ b/properties_of_stars/foundational.ipynb
@@ -42,6 +42,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoRun": "true",
     "hideCode": "true"
    },
    "outputs": [],
@@ -83,6 +84,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoRun": "true",
     "hideCode": "true"
    },
    "outputs": [],
@@ -104,6 +106,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoRun": "true",
     "hideCode": "true"
    },
    "outputs": [],
@@ -136,6 +139,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoRun": "true",
     "hideCode": "true"
    },
    "outputs": [],
@@ -158,6 +162,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoRun": "true",
     "hideCode": "true"
    },
    "outputs": [],
@@ -189,6 +194,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoRun": "true",
     "hideCode": "true"
    },
    "outputs": [],


### PR DESCRIPTION
This should tell the plugin to automatically run these cells upon
loading the notebook.